### PR TITLE
patch: support python 3.11 which doesn't support pyyaml 5.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,10 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "^3.8"
 requests = "^2.25.1"
-PyYAML = "^5.4.1"
+PyYAML = [
+	{ version = "^5.4.1", python = "<3.11"},
+	{ version = "^6.0.1", python = ">=3.11"}
+]
 
 [tool.poetry.dev-dependencies]
 black = "^21.9b0"


### PR DESCRIPTION
Python 3.11 expects PEP 517 builds. Pyyaml 5.4 does not support them, but pyyaml 6.0 does. This PR updates pyyaml for python 3.11 without changing pyyaml version for earlier python versions.