### PR TITLE
patch: Use days=365 for coingecko api compatibility

### DIFF
--- a/waxtax/__main__.py
+++ b/waxtax/__main__.py
@@ -120,7 +120,7 @@ def waxtax():
     endpoints = pre_checks(config=config,mode=mode)
     # Get price data for currency
     prices = requests.get(
-        f"https://api.coingecko.com/api/v3/coins/wax/market_chart?vs_currency={CURRENCY.lower()}&days=max"
+        f"https://api.coingecko.com/api/v3/coins/wax/market_chart?vs_currency={CURRENCY.lower()}&days=365"
     )
     try:
         history = dict(prices.json()["prices"])


### PR DESCRIPTION
The coingecko api gives the following error for requests with "max" days:

`{"error":{"status":{"timestamp":"2024-04-20T22:00:05.123+00:00","error_code":10012,"error_message":"Your request exceeds the allowed time range. Public API users are limited to querying historical data within the past 365 days. Upgrade to a paid plan to enjoy full historical data access: https://www.coingecko.com/en/api/pricing. "}}}`

This PR uses the max free duration of 365 days instead of exiting at this point in execution.